### PR TITLE
add MapUser class

### DIFF
--- a/circleguard/__init__.py
+++ b/circleguard/__init__.py
@@ -1,7 +1,7 @@
 import logging
 
 from circleguard.circleguard import Circleguard, set_options
-from circleguard.replay import Check, Replay, ReplayMap, ReplayPath, Map, User
+from circleguard.replay import Check, Replay, ReplayMap, ReplayPath, Map, User, MapUser
 from circleguard.enums import Detect, RatelimitWeight, Keys, StealDetect, RelaxDetect, Mod, CorrectionDetect
 from circleguard.utils import TRACE, ColoredFormatter
 from circleguard.loader import Loader
@@ -26,4 +26,4 @@ __all__ = ["Circleguard", "set_options", "Check", "Replay", "ReplayMap", "StealD
            "CircleguardException", "InvalidArgumentsException", "Map", "User",
            "APIException", "NoInfoAvailableException", "UnknownAPIException", "InternalAPIException",
            "InvalidKeyException", "RatelimitException", "InvalidJSONException", "ReplayUnavailableException", "Keys",
-           "Mod", "CorrectionResult"]
+           "Mod", "CorrectionResult", "MapUser"]

--- a/circleguard/comparer.py
+++ b/circleguard/comparer.py
@@ -144,8 +144,6 @@ class Comparer:
         # remove time and keys from each tuple
         data1 = [d[1:3] for d in data1]
         data2 = [d[1:3] for d in data2]
-        print(Mod.HR in replay1.mods)
-        print(Mod.HR in replay2.mods)
         if (Mod.HR in replay1.mods) ^ (Mod.HR in replay2.mods): # xor, if one has hr but not the other
             for d in data1:
                 d[1] = 384 - d[1]

--- a/circleguard/loader.py
+++ b/circleguard/loader.py
@@ -176,7 +176,7 @@ class Loader():
         Notes
         -----
         One of ``num``, ``user_id``, and ``span`` must be passed, but not both
-        ``num`` and either ``user_id`` or ``span``.
+        ``num`` and ``span``.
 
         Raises
         ------
@@ -196,8 +196,8 @@ class Loader():
         if num and (num > 100 or num < 1):
             raise InvalidArgumentsException("The number of top plays to fetch must be between 1 and 100 inclusive!")
 
-        if not bool(user_id) ^ (bool(num) or bool(span)):
-            raise InvalidArgumentsException("One of num, user_id, or span must be passed, but not both num and either user_id or span")
+        if (num and span) or not (num or user_id or span):
+            raise InvalidArgumentsException("One of num, user_id, or span must be passed, but not both num and span")
         if span:
             span_list = span_to_list(span)
             num = max(span_list)

--- a/circleguard/loader.py
+++ b/circleguard/loader.py
@@ -206,7 +206,7 @@ class Loader():
         if span:
             # filter span_list to remove indexes that would cause an indexerror
             # when indexing ``response``
-            # span = {3, 6}; response = [a, b, c, d, e, f]; len(response) = 6
+            # span_list = {3, 6}; response = [a, b, c, d, e, f]; len(response) = 6
             # we want to keep {6} since we index at [i-1], so use <= not <
             span_list = {x for x in span_list if x <= len(response)}
             # filter out anything not in our span

--- a/circleguard/loader.py
+++ b/circleguard/loader.py
@@ -204,6 +204,11 @@ class Loader():
         response = self.api.get_scores({"m": "0", "b": map_id, "limit": num, "u": user_id, "mods": mods if mods is None else mods.value})
         Loader.check_response(response)
         if span:
+            # filter span_list to remove indexes that would cause an indexerror
+            # when indexing ``response``
+            # span = {3, 6}; response = [a, b, c, d, e, f]; len(response) = 6
+            # we want to keep {6} since we index at [i-1], so use <= not <
+            span_list = {x for x in span_list if x <= len(response)}
             # filter out anything not in our span
             response = [response[i-1] for i in span_list]
         # yes, it's necessary to cast the str response to int before bool - all strings are truthy.


### PR DESCRIPTION
add a `MapUser` class that represents all of a user's replays on a map. Has isolated use cases, but mainly implemented to allow for remod checks, which were impossible previously in this rewrite without using `Loader` and a mess of internal stuff.

```python
user = User(6304246, span="1")
cg.load_info(user)

for replay in user:
    map_id = replay.map_id
    remod_replays = MapUser(replay.map_id, 6304246, span="2 - 100")
    cg.load_info(remod_replays)
    print(remod_replays.replays)
    check = Check([replay, remod_replays], detect=StealDetect())
    for r in cg.run(check):
        print(r.replay1.mods)
        print(r.replay2.mods)
```

This wasn't doable as an extension to `User` or `Map` (I considered it) because they are `ReplayContainer`s that hold `Replay`s, and are not build to hold other `ReplayContainers`. It would also make iterating over them a nightmare of type checking for the end user.