### PR TITLE
sphinx version and footer fix

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -4,9 +4,9 @@
 # list see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 
-# This will fail if circlecore's dependencies aren't installed.
-# Which shouldn't be an issue because the only people running ``make html``
-# (building the docs) are people with circlecore properly installed, hopefully.
+import os, sys
+# prefer local package over installed one
+sys.path.insert(0, os.path.dirname(os.getcwd()))
 from circleguard import __version__
 
 project = "Circleguard"

--- a/source/conf.py
+++ b/source/conf.py
@@ -4,9 +4,9 @@
 # list see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 
-import os, sys
-# prefer local package over installed one
-sys.path.insert(0, os.path.dirname(os.getcwd()))
+# This will fail if circlecore's dependencies aren't installed.
+# Which shouldn't be an issue because the only people running ``make html``
+# (building the docs) are people with circlecore properly installed, hopefully.
 from circleguard import __version__
 
 project = "Circleguard"

--- a/source/conf.py
+++ b/source/conf.py
@@ -4,11 +4,16 @@
 # list see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 
+# This will fail if circlecore's dependencies aren't installed.
+# Which shouldn't be an issue because the only people running ``make html``
+# (building the docs) are people with circlecore properly installed, hopefully.
+from circleguard import __version__
+
 project = "Circleguard"
 copyright = "2019, Liam DeVoe, samuelhklumpers, InvisibleSymbol"
 author = "Liam DeVoe, samuelhklumpers, InvisibleSymbol"
-release = "2.4.0"
-version = "2.4.0"
+release = "v" + __version__
+version = "v" + __version__
 master_doc = 'index'
 
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-html_show_copyright

--- a/source/conf.py
+++ b/source/conf.py
@@ -11,6 +11,11 @@ release = "2.4.0"
 version = "2.4.0"
 master_doc = 'index'
 
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-html_show_copyright
+html_show_copyright = False
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-html_show_sphinx
+html_show_sphinx = False
+
 extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.napoleon",


### PR DESCRIPTION
Cleaner footer, use `__version__` from circleguard. I don't think this will actually change anything about our docs until we self host and move off rtd.