### PR TITLE
fix Mod subtraction

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,3 +2,4 @@
 * Fix incorrect `__add__` method for `Check`
 * Rename `Keys` to `Key` (`Keys` left available as deprecated)
 * Don't double load `ReplayInfo` when using `Map`
+* fix mod subtraction not being commutative (eg `Mod.HDHR - Mod.HR` has a different meaning from `Mod.HR - Mod.HDHR`)

--- a/circleguard/enums.py
+++ b/circleguard/enums.py
@@ -147,7 +147,7 @@ class ModCombination():
         return ModCombination(self.value | other.value)
 
     def __sub__(self, other):
-        return ModCombination(self.value ^ other.value)
+        return ModCombination(self.value & ~other.value)
 
     def __hash__(self):
         return self.value


### PR DESCRIPTION
previously, `Mod.NM - Mod.HR` would return `Mod.HR`, since it was an xor. This is contrary to what we expect from subtraction (subtraction is not commutative; xor is).

Now:

```python
>>> Mod.HDHR - Mod.HR
ModCombination(value=8)
>>> Mod.HR - Mod.NM
ModCombination(value=16)
>>> Mod.NM - Mod.NF
ModCombination(value=0)
```