### PR TITLE
Fix loader

### DIFF
--- a/circleguard/loadable.py
+++ b/circleguard/loadable.py
@@ -663,6 +663,7 @@ class ReplayPath(Replay):
     def __init__(self, path, cache=None):
         self.log = logging.getLogger(__name__ + ".ReplayPath")
         self.path = path
+        self.hash = None
         self.cache = cache
         self.weight = RatelimitWeight.LIGHT
         self.loaded = False
@@ -708,6 +709,7 @@ class ReplayPath(Replay):
         loaded = circleparse.parse_replay_file(self.path)
         map_id = loader.map_id(loaded.beatmap_hash)
         user_id = loader.user_id(loaded.player_name)
+        self.hash = loaded.beatmap_hash
 
         Replay.__init__(self, loaded.timestamp, map_id, loaded.player_name, user_id, ModCombination(loaded.mod_combination),
                         loaded.replay_id, loaded.play_data, self.weight)

--- a/circleguard/loader.py
+++ b/circleguard/loader.py
@@ -376,10 +376,11 @@ class Loader():
         """
 
         response = self.api.get_beatmaps({"h": map_hash})
-        if response == []:
+        try:
+            Loader.check_response(response)
+        except NoInfoAvailableException:
             return 0
-        else:
-            return int(response[0]["beatmap_id"])
+        return int(response[0]["beatmap_id"])
 
     @lru_cache()
     def user_id(self, username):
@@ -412,10 +413,11 @@ class Loader():
         """
 
         response = self.api.get_user({"u": username, "type": "string"})
-        if response == []:
+        try:
+            Loader.check_response(response)
+        except NoInfoAvailableException:
             return 0
-        else:
-            return int(response[0]["user_id"])
+        return int(response[0]["user_id"])
 
     @lru_cache()
     def username(self, user_id):
@@ -442,10 +444,11 @@ class Loader():
         duplicate api calls.
         """
         response = self.api.get_user({"u": user_id, "type": "id"})
-        if response == []:
+        try:
+            Loader.check_response(response)
+        except NoInfoAvailableException:
             return ""
-        else:
-            return response[0]["username"]
+        return response[0]["username"]
 
     @staticmethod
     def check_response(response):

--- a/tests/test.py
+++ b/tests/test.py
@@ -3,7 +3,7 @@ from unittest import TestCase, skip, TestSuite, TextTestRunner
 from pathlib import Path
 import warnings
 from circleguard import (Circleguard, Check, ReplayMap, ReplayPath, RelaxDetect, StealDetect,
-                         RatelimitWeight, set_options, Map, User, MapUser, Mod, Loader)
+                         RatelimitWeight, set_options, Map, User, MapUser, Mod, Loader, InvalidKeyException)
 
 KEY = os.environ.get('OSU_API_KEY')
 if not KEY:
@@ -237,6 +237,12 @@ class TestLoader(CGTestCase):
     def test_working_username(self):
         result = self.loader.username(13506780)
         self.assertEqual(result, "] [")
+
+    def test_incorrect_key(self):
+        loader = Loader("LULW 727 LULW")
+        self.assertRaises(InvalidKeyException, loader.username, 13506780)
+        self.assertRaises(InvalidKeyException, loader.user_id, "] [")
+        self.assertRaises(InvalidKeyException, loader.map_id, "9d0a8fec2fe3f778334df6bdc60b113c")
 
 
 if __name__ == '__main__':

--- a/tests/test.py
+++ b/tests/test.py
@@ -3,7 +3,7 @@ from unittest import TestCase, skip, TestSuite, TextTestRunner
 from pathlib import Path
 import warnings
 from circleguard import (Circleguard, Check, ReplayMap, ReplayPath, RelaxDetect, StealDetect,
-                         RatelimitWeight, set_options, Map, User, MapUser, Mod)
+                         RatelimitWeight, set_options, Map, User, MapUser, Mod, Loader)
 
 KEY = os.environ.get('OSU_API_KEY')
 if not KEY:
@@ -17,6 +17,7 @@ set_options(loglevel=20)
 # We may want to split tests into "heavy" and "light" where light loads <10 heavy calls and heavy loads as many as we need.
 # light can run locally, heavy can run on prs.
 HEAVY_CALL_COUNT = 9
+
 
 class CGTestCase(TestCase):
     @classmethod
@@ -34,8 +35,8 @@ class CGTestCase(TestCase):
                 message="unclosed",
                 category=ResourceWarning)
 
-class TestReplays(CGTestCase):
 
+class TestReplays(CGTestCase):
     def test_cheated_replaypath(self):
         # taken from http://redd.it/bvfv8j, remodded replay by same user (CielXDLP) from HDHR to FLHDHR
         replays = [ReplayPath(RES / "stolen_replay1.osr"), ReplayPath(RES / "stolen_replay2.osr")]
@@ -107,7 +108,6 @@ class TestReplays(CGTestCase):
         self.assertTrue(r.loaded, "Loaded status was not correct")
 
 
-
 class TestMap(CGTestCase):
     @classmethod
     def setUpClass(cls):
@@ -172,6 +172,7 @@ class TestUser(CGTestCase):
         # 1st and 3rd (FDFD and Remote Control)
         self.assertListEqual([r.map_id for r in self.user[0:3:2]], [129891, 774965])
 
+
 class TestMapUser(CGTestCase):
     @classmethod
     def setUpClass(cls):
@@ -202,6 +203,33 @@ class TestMapUser(CGTestCase):
         self.assertEqual(self.mu[1].map_id, 795627)
         # test slicing
         self.assertListEqual([r.map_id for r in self.mu[0:2]], [795627, 795627])
+
+
+class TestLoader(CGTestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.loader = Loader(KEY)
+
+    def test_wrong_map_id(self):
+        result = self.loader.map_id("E")
+        self.assertEqual(result, 0)
+
+    def test_working_map_id(self):
+        result = self.loader.map_id("9d0a8fec2fe3f778334df6bdc60b113c")
+        self.assertEqual(result, 221777)
+
+    def test_wrong_user_id(self):
+        result = self.loader.user_id("E")
+        self.assertEqual(result, 0)
+
+    def test_working_user_id1(self):
+        result = self.loader.user_id("] [")
+        self.assertEqual(result, 13506780)
+
+    def test_working_user_id2(self):
+        result = self.loader.user_id("727")
+        self.assertEqual(result, 10750899)
+
 
 if __name__ == '__main__':
     suite = TestSuite()

--- a/tests/test.py
+++ b/tests/test.py
@@ -210,36 +210,32 @@ class TestLoader(CGTestCase):
     def setUpClass(cls):
         cls.loader = Loader(KEY)
 
-    def test_incorrect_map_id(self):
+    def test_loading_map_id(self):
         result = self.loader.map_id("E")
         self.assertEqual(result, 0)
 
-    def test_working_map_id(self):
         result = self.loader.map_id("9d0a8fec2fe3f778334df6bdc60b113c")
         self.assertEqual(result, 221777)
 
-    def test_incorrect_user_id(self):
+    def test_loading_user_id(self):
         result = self.loader.user_id("E")
         self.assertEqual(result, 0)
 
-    def test_working_user_id1(self):
         result = self.loader.user_id("] [")
         self.assertEqual(result, 13506780)
 
-    def test_working_user_id2(self):
         result = self.loader.user_id("727")
         self.assertEqual(result, 10750899)
 
-    def test_incorrect_username(self):
+    def test_loading_username(self):
         result = self.loader.username(0)
         self.assertEqual(result, "")
 
-    def test_working_username(self):
         result = self.loader.username(13506780)
         self.assertEqual(result, "] [")
 
     def test_incorrect_key(self):
-        loader = Loader("LULW 727 LULW")
+        loader = Loader("incorrect key")
         self.assertRaises(InvalidKeyException, loader.username, 13506780)
         self.assertRaises(InvalidKeyException, loader.user_id, "] [")
         self.assertRaises(InvalidKeyException, loader.map_id, "9d0a8fec2fe3f778334df6bdc60b113c")

--- a/tests/test.py
+++ b/tests/test.py
@@ -210,7 +210,7 @@ class TestLoader(CGTestCase):
     def setUpClass(cls):
         cls.loader = Loader(KEY)
 
-    def test_wrong_map_id(self):
+    def test_incorrect_map_id(self):
         result = self.loader.map_id("E")
         self.assertEqual(result, 0)
 
@@ -218,7 +218,7 @@ class TestLoader(CGTestCase):
         result = self.loader.map_id("9d0a8fec2fe3f778334df6bdc60b113c")
         self.assertEqual(result, 221777)
 
-    def test_wrong_user_id(self):
+    def test_incorrect_user_id(self):
         result = self.loader.user_id("E")
         self.assertEqual(result, 0)
 
@@ -230,7 +230,7 @@ class TestLoader(CGTestCase):
         result = self.loader.user_id("727")
         self.assertEqual(result, 10750899)
 
-    def test_wrong_username(self):
+    def test_incorrect_username(self):
         result = self.loader.username(0)
         self.assertEqual(result, "")
 

--- a/tests/test.py
+++ b/tests/test.py
@@ -230,6 +230,14 @@ class TestLoader(CGTestCase):
         result = self.loader.user_id("727")
         self.assertEqual(result, 10750899)
 
+    def test_wrong_username(self):
+        result = self.loader.username(0)
+        self.assertEqual(result, "")
+
+    def test_working_username(self):
+        result = self.loader.username(13506780)
+        self.assertEqual(result, "] [")
+
 
 if __name__ == '__main__':
     suite = TestSuite()


### PR DESCRIPTION
`response` wasn't being checked, array operation caused an `KeyError` when an invalid key was specified. Now raises an correct `InvalidKeyException`.