### PR TITLE
allow Mod to be instantiated, add string instantiation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 * mods can now be instantiated through `Mod`. Instantiation through `ModCombination` is highly discouraged.
 * mods can now be instantiated with a string, not only an int. The string
 must be a combination, in any order, of the two length strings that represent mods. For instance, `Mod("HDHR")` is valid, and `Mod("HDHR") == Mod.HDHR` is `True`.
+* add `Mod.ALL` which contains all atomic (single) mods defined by `Mod`. This differs from `Mod.ORDER` in that it includes `Mod.NM`.
 
 # v3.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 * rename `ReplayStealingResult` to `StealResult` (for consistency with `Result` names matching their respective `Detect` names). `ReplayStealingResult` left available as deprecated.
+* mods can now be instantiated through `Mod`. Instantiation through `ModCombination` is highly discouraged.
+* mods can now be instantiated with a string, not only an int. The string
+must be a combination, in any order, of the two length strings that represent mods. For instance, `Mod("HDHR")` is valid, and `Mod("HDHR") == Mod.HDHR` is `True`.
 
 # v3.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# Unreleased
+
 * rename `ReplayStealingResult` to `StealResult` (for consistency with `Result` names matching their respective `Detect` names). `ReplayStealingResult` left available as deprecated.
 * mods can now be instantiated through `Mod`. Instantiation through `ModCombination` is highly discouraged.
 * mods can now be instantiated with a string, not only an int. The string

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 * mods can now be instantiated through `Mod`. Instantiation through `ModCombination` is highly discouraged.
 * mods can now be instantiated with a string, not only an int. The string
 must be a combination, in any order, of the two length strings that represent mods. For instance, `Mod("HDHR")` is valid, and `Mod("HDHR") == Mod.HDHR` is `True`.
-* add `Mod.ALL` which contains all atomic (single) mods defined by `Mod`. This differs from `Mod.ORDER` in that it includes `Mod.NM`.
 
 # v3.1.0
 

--- a/circleguard/enums.py
+++ b/circleguard/enums.py
@@ -273,9 +273,9 @@ class Mod(ModCombination):
              FI, RD, CN ,TP, K1, K2, K3, K4, K5, K6, K7, K8, K9, CO, MR]
 
     def __init__(self, value):
-        if type(value) is int:
+        if isinstance(value, int):
             super().__init__(value)
-        if type(value) is str:
+        if isinstance(value, str):
             super().__init__(Mod._parse_mod_string(value))
 
     @staticmethod
@@ -309,7 +309,7 @@ class Mod(ModCombination):
             single_mod_string = mod_string[i - 2: i]
             # there better only be one Mod that has an acronym matching ours,
             # but a comp + 0 index works too
-            matching_mods = [mod for mod in Mod.ALL if mod.short_name() == single_mod_string]
+            matching_mods = [mod for mod in Mod.ORDER if mod.short_name() == single_mod_string]
             if not matching_mods:
                 raise ValueError(f"Invalid mod string (no matching mod found for {single_mod_string})")
             mod_value += matching_mods[0].value

--- a/circleguard/enums.py
+++ b/circleguard/enums.py
@@ -306,12 +306,12 @@ class Mod(ModCombination):
             raise ValueError(f"Invalid mod string {mod_string} (not of even length)")
         mod_value = 0
         for i in range(0, len(mod_string) - 1, 2):
-            single_mod_string = mod_string[i: i + 2]
+            single_mod = mod_string[i: i + 2]
             # there better only be one Mod that has an acronym matching ours,
             # but a comp + 0 index works too
-            matching_mods = [mod for mod in Mod.ORDER if mod.short_name() == single_mod_string]
+            matching_mods = [mod for mod in Mod.ORDER if mod.short_name() == single_mod]
             if not matching_mods:
-                raise ValueError(f"Invalid mod string (no matching mod found for {single_mod_string})")
+                raise ValueError(f"Invalid mod string (no matching mod found for {single_mod})")
             mod_value += matching_mods[0].value
         return mod_value
 

--- a/circleguard/enums.py
+++ b/circleguard/enums.py
@@ -268,13 +268,9 @@ class Mod(ModCombination):
     # our own, more human readable docstrings. #: denotes sphinx docstrings.
     #: [EZ, HD, HT, DT, _NC, HR, FL, NF, SD, _PF, RX, AP, SO, AT, V2, TD,
     #: FI, RD, CN ,TP, K1, K2, K3, K4, K5, K6, K7, K8, K9, CO, MR]
-    ORDER = [EZ, HD, HT, DT, _NC, HR, FL, NF, SD, _PF, RX, AP, SO, AT,
+    ORDER = [NM, EZ, HD, HT, DT, _NC, HR, FL, NF, SD, _PF, RX, AP, SO, AT,
              V2, TD, # we stop caring about order after this point
              FI, RD, CN ,TP, K1, K2, K3, K4, K5, K6, K7, K8, K9, CO, MR]
-
-    # same as ORDER but with NM included
-    ALL = [NM, EZ, HD, HT, DT, _NC, HR, FL, NF, SD, _PF, RX, AP, SO, AT,
-           V2, TD, FI, RD, CN ,TP, K1, K2, K3, K4, K5, K6, K7, K8, K9, CO, MR]
 
     def __init__(self, value):
         if type(value) is int:

--- a/circleguard/enums.py
+++ b/circleguard/enums.py
@@ -270,7 +270,7 @@ class Mod(ModCombination):
     #: FI, RD, CN ,TP, K1, K2, K3, K4, K5, K6, K7, K8, K9, CO, MR]
     ORDER = [NM, EZ, HD, HT, DT, _NC, HR, FL, NF, SD, _PF, RX, AP, SO, AT,
              V2, TD, # we stop caring about order after this point
-             FI, RD, CN ,TP, K1, K2, K3, K4, K5, K6, K7, K8, K9, CO, MR]
+             FI, RD, CN, TP, K1, K2, K3, K4, K5, K6, K7, K8, K9, CO, MR]
 
     def __init__(self, value):
         if isinstance(value, int):

--- a/circleguard/enums.py
+++ b/circleguard/enums.py
@@ -305,8 +305,8 @@ class Mod(ModCombination):
         if len(mod_string) % 2 != 0:
             raise ValueError(f"Invalid mod string {mod_string} (not of even length)")
         mod_value = 0
-        for i in range(2, len(mod_string) + 1, 2):
-            single_mod_string = mod_string[i - 2: i]
+        for i in range(0, len(mod_string) - 1, 2):
+            single_mod_string = mod_string[i: i + 2]
             # there better only be one Mod that has an acronym matching ours,
             # but a comp + 0 index works too
             matching_mods = [mod for mod in Mod.ORDER if mod.short_name() == single_mod_string]


### PR DESCRIPTION
* mods can now be instantiated through `Mod`. Instantiation through `ModCombination` is highly discouraged.
* mods can now be instantiated with a string, not only an int. The string
must be a combination, in any order, of the two length strings that represent mods. For instance, `Mod("HDHR")` is valid, and `Mod("HDHR") == Mod.HDHR` is `True`.