### PR TITLE
use sorted unique timestamps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   * changes similarity values slightly, both increasing and decreasing simvals for legit and stolen replays.
   * no measurable impact on the effectiveness of circlecore to detect stolen replays.
   * increases comparison speed.
+* use only unique timestamps when interpolating (also changes similarity values slightly)
 
 # v3.1.0
 

--- a/circleguard/loadable.py
+++ b/circleguard/loadable.py
@@ -541,8 +541,7 @@ class Replay(Loadable):
         xy = np.array([block[1], block[2]], dtype=float).T
         k = np.array(block[3], dtype=int)
 
-        t_sort = np.argsort(t)
-        t = t[t_sort]
+        t, t_sort = np.unique(t, return_index=True)
         xy = xy[t_sort]
         k = k[t_sort]
 

--- a/tests/test.py
+++ b/tests/test.py
@@ -51,7 +51,7 @@ class TestReplays(CGTestCase):
         earlier = r.earlier_replay
         later = r.later_replay
 
-        self.assertAlmostEqual(r.similarity, 2.1911, delta=0.0001, msg="Similarity is not correct")
+        self.assertAlmostEqual(r.similarity, 2.1923, delta=0.0001, msg="Similarity is not correct")
         self.assertEqual(r1.map_id, r2.map_id, "Replay map ids did not match")
         self.assertEqual(r1.map_id, 1988753, "Replay map id was not correct")
         self.assertEqual(earlier.mods, Mod.HD + Mod.HR, "Earlier replay mods was not correct")
@@ -73,7 +73,7 @@ class TestReplays(CGTestCase):
         earlier = r.earlier_replay
         later = r.later_replay
 
-        self.assertAlmostEqual(r.similarity, 23.6604, delta=0.0001, msg="Similarity is not correct")
+        self.assertAlmostEqual(r.similarity, 23.0359, delta=0.0001, msg="Similarity is not correct")
         self.assertEqual(r1.map_id, r2.map_id, "Replay map ids did not match")
         self.assertEqual(r1.map_id, 722238, "Replay map id was not correct")
         self.assertEqual(earlier.mods, Mod.HD + Mod.NC, "Earlier replay mods was not correct")
@@ -124,7 +124,7 @@ class TestReplays(CGTestCase):
             earlier = r.earlier_replay
             later = r.later_replay
 
-            self.assertAlmostEqual(r.similarity, 2.1911, delta=0.0001, msg=f"Similarity is not correct at num {num}")
+            self.assertAlmostEqual(r.similarity, 2.1923, delta=0.0001, msg=f"Similarity is not correct at num {num}")
             self.assertEqual(r1.map_id, r2.map_id, f"Replay map ids did not match at num {num}")
             self.assertEqual(r1.map_id, 1988753, f"r1 map id was not correct at num {num}")
             self.assertEqual(earlier.mods, Mod.HD + Mod.HR, f"Earlier replay mods was not correct at num {num}")


### PR DESCRIPTION
use only unique timestamps when interpolating (changes similarity values slightly)