### PR TITLE
Add hill climbing test and CMode structure

### DIFF
--- a/circleguard/__init__.py
+++ b/circleguard/__init__.py
@@ -2,7 +2,7 @@ import logging
 
 from circleguard.circleguard import Circleguard, set_options
 from circleguard.loadable import Check, Replay, ReplayMap, ReplayPath, Map, User, MapUser, ReplayContainer, LoadableContainer, Loadable
-from circleguard.enums import Detect, RatelimitWeight, Keys, Key, StealDetect, RelaxDetect, Mod, CorrectionDetect
+from circleguard.enums import Detect, RatelimitWeight, Keys, Key, StealDetect, RelaxDetect, Mod, CorrectionDetect, CMode, StandardCMode, SearchCMode, FastCMode, SlowCMode
 from circleguard.utils import TRACE, ColoredFormatter
 from circleguard.loader import Loader
 from circleguard.replay_info import ReplayInfo
@@ -26,4 +26,5 @@ __all__ = ["Circleguard", "set_options", "Check", "Replay", "ReplayMap", "StealD
            "CircleguardException", "InvalidArgumentsException", "Map", "User",
            "APIException", "NoInfoAvailableException", "UnknownAPIException", "InternalAPIException",
            "InvalidKeyException", "RatelimitException", "InvalidJSONException", "ReplayUnavailableException", "Keys", "Key",
-           "Mod", "CorrectionResult", "MapUser", "ReplayContainer", "LoadableContainer", "Loadable"]
+           "Mod", "CorrectionResult", "MapUser", "ReplayContainer", "LoadableContainer", "Loadable", "CMode",
+           "StandardCMode", "SearchCMode", "FastCMode", "SlowCMode"]

--- a/circleguard/circleguard.py
+++ b/circleguard/circleguard.py
@@ -96,7 +96,7 @@ class Circleguard:
         if Detect.STEAL in d:
             compare1 = c.all_replays()
             compare2 = c.all_replays2()
-            comparer = Comparer(d.steal_thresh, compare1, replays2=compare2)
+            comparer = Comparer(d, compare1, replays2=compare2)
             yield from comparer.compare()
 
         # relax check

--- a/circleguard/comparer.py
+++ b/circleguard/comparer.py
@@ -104,7 +104,7 @@ class Comparer:
         """
         self.log.log(utils.TRACE, "comparing %r and %r", replay1, replay2)
 
-        cmode = self.detect.clean_mode
+        cmode = self.detect.cmode
         means = []
         if CMode.SEARCH in cmode:
             mean = Comparer._compare_hill_climb(replay1, replay2, cmode)

--- a/circleguard/comparer.py
+++ b/circleguard/comparer.py
@@ -206,8 +206,7 @@ class Comparer:
           current similarity.
         """
 
-        t1, xy1, k1 = replay1.t, replay1.xy, replay1.k
-        t2, xy2, k2 = replay2.t, replay2.xy, replay2.k
+        t1 = replay1.t
         prev_value = math.inf # arbitrarily high value
 
         dt = search_cmode.search_step
@@ -224,8 +223,7 @@ class Comparer:
                 value = Comparer._compare_two_replays(replay1, replay2)
 
                 values[value] = v
-                replay1.t, replay1.xy, replay1.k = t1, xy1, k1
-                replay2.t, replay2.xy, replay2.k = t2, xy2, k2
+                replay1.t = t1
 
             # take the times with the lowest similarity
             min_value = min(values)

--- a/circleguard/comparer.py
+++ b/circleguard/comparer.py
@@ -207,7 +207,8 @@ class Comparer:
         """
 
         t1 = replay1.t
-        prev_value = math.inf # arbitrarily high value
+        # start with sim value at 0 shift
+        prev_value = Comparer._compare_two_replays(replay1, replay2)
 
         dt = search_cmode.search_step
         step_limit = search_cmode.step_limit

--- a/circleguard/comparer.py
+++ b/circleguard/comparer.py
@@ -104,11 +104,9 @@ class Comparer:
             The result of comparing ``replay1`` to ``replay2``.
         """
         self.log.log(utils.TRACE, "comparing %r and %r", replay1, replay2)
-        result = Comparer._compare_two_replays(replay1, replay2)
+        mean = Comparer._compare_two_replays(replay1, replay2)
         result2 = Comparer._compare_hill_climb(replay1, replay2)
-        print(f"normal comparison: {result[0]:.6f}, hill climb: {result2:.6f}")
-        mean = result[0]
-        sigma = result[1]
+        print(f"normal comparison: {mean:.6f}, hill climb: {result2:.6f}")
         ischeat = False
         if(mean < self.threshold):
             ischeat = True
@@ -156,8 +154,8 @@ class Comparer:
         if (Mod.HR in replay1.mods) ^ (Mod.HR in replay2.mods):
             xy1[:, 1] = 384 - xy1[:, 1]
 
-        (mu, sigma) = Comparer._compute_data_similarity(xy1, xy2)
-        return (mu, sigma)
+        mean = Comparer._compute_data_similarity(xy1, xy2)
+        return mean
 
     @staticmethod
     def _compare_hill_climb(replay1, replay2):
@@ -275,9 +273,7 @@ class Comparer:
         # => [ d_1 ... d_2 ]
         distance = (distance ** 2).sum(axis=1) ** 0.5
 
-        mu, sigma = distance.mean(), distance.std()
-
-        return (mu, sigma)
+        return distance.mean()
 
     def __repr__(self):
         return f"Comparer(threshold={self.threshold},replays1={self.replays1},replays2={self.replays2})"

--- a/circleguard/comparer.py
+++ b/circleguard/comparer.py
@@ -221,7 +221,7 @@ class Comparer:
                 replay1.t = t1 + sgn * dt
                 v = replay1.t
 
-                value = Comparer._compare_two_replays(replay1, replay2)[0]
+                value = Comparer._compare_two_replays(replay1, replay2)
 
                 values[value] = v
                 replay1.t, replay1.xy, replay1.k = t1, xy1, k1

--- a/circleguard/enums.py
+++ b/circleguard/enums.py
@@ -318,16 +318,17 @@ class Mod(ModCombination):
         return mod_value
 
 
-class CleanMode():
+class CMode():
     """
-    A combination of the options used to clean replays before comparison.
+    Specifies the algorithm used in order to compare two replays
+    (Comparison Mode).
 
     Parameters
     ----------
     value: int
         The clean mode(s) to use. One (or a bitwise combination) of
-        :data:`~.CleanMode.VALIDATE`, :data:`~.CleanMode.SYNCHRONIZE`,
-        :data:`~.CleanMode.ALIGN`, or :data:`~.CleanMode.SEARCH`.
+        :data:`~.CMode.VALIDATE`, :data:`~.CMode.SYNCHRONIZE`,
+        :data:`~.CMode.ALIGN`, or :data:`~.CMode.SEARCH`.
     """
     # no-op
     NONE         = 0
@@ -346,15 +347,15 @@ class CleanMode():
         return not bool(~self.value & other)
 
     def __add__(self, other):
-        ret = CleanMode(self.value | other.value)
+        ret = CMode(self.value | other.value)
 
-        c = self if CleanMode.SEARCH in self else other if CleanMode.SEARCH in other else None
+        c = self if CMode.SEARCH in self else other if CMode.SEARCH in other else None
         if c:
             ret.search_step = c.search_step
             ret.step_limit = c.step_limit
         return ret
 
-class StandardCMode(CleanMode):
+class StandardCMode(CMode):
     """
     Removes frames with an x or y coordinate outside of the play area
     (512 by 384). Interpolates one replay to the other, then compares each frame
@@ -365,12 +366,12 @@ class StandardCMode(CleanMode):
     -----
     This is the standard comparison algorithm, used in circlecore since almost
     the very beginning. It has incredibly few false positives, but may let some
-    false negatives slip through. See other ``CleanMode``\s for alternatives.
+    false negatives slip through. See other ``CMode``\s for alternatives.
     """
     def __init__(self):
-        super().__init__(CleanMode.STANDARD)
+        super().__init__(CMode.STANDARD)
 
-class SearchCMode(CleanMode):
+class SearchCMode(CMode):
     """
     Uses a local search (hill climbing) that shifts replays forwards and/or
     backwards through time to try and find a local minimum for the similarity.
@@ -387,16 +388,16 @@ class SearchCMode(CleanMode):
         are willing to do to find a local minimum.
     """
     def __init__(self, search_step=16, step_limit=10):
-        super().__init__(CleanMode.SEARCH)
+        super().__init__(CMode.SEARCH)
         self.search_step = search_step
         self.step_limit = step_limit
 
-class FastCMode(CleanMode):
+class FastCMode(CMode):
     """
     The fast clean mode preset. Effective in most situations, but not when
     one replay has been shifted through time.
 
-    This is usually the economic :class:`~.CleanMode` choice, unless you
+    This is usually the economic :class:`~.CMode` choice, unless you
     suspect the replay has been shifted through time (or are not concerned
     about extra comparison time), in which case use :class:`~.SlowCMode`.
 
@@ -409,9 +410,9 @@ class FastCMode(CleanMode):
     :class:`~.SlowCMode`, for a slower but more effective alternative.
     """
     def __init__(self):
-        super().__init__(CleanMode.FAST)
+        super().__init__(CMode.FAST)
 
-class SlowCMode(CleanMode):
+class SlowCMode(CMode):
     """
     The slow clean mode preset. Effective in almost all situations, including
     when one replay has been shifted through time.
@@ -427,7 +428,7 @@ class SlowCMode(CleanMode):
     :class:`~.SlowCMode`, for a faster but less effective alternative.
     """
     def __init__(self):
-        super().__init__(CleanMode.SLOW)
+        super().__init__(CMode.SLOW)
 
 
 class Detect():

--- a/circleguard/enums.py
+++ b/circleguard/enums.py
@@ -452,6 +452,7 @@ class Detect():
 
         # so we can reference them in :func:`~.__add__`
         self.steal_thresh = None
+        self.cmode = None
         self.ur_thresh = None
         self.max_angle = None
         self.min_distance = None
@@ -464,6 +465,7 @@ class Detect():
         d = self if Detect.STEAL in self else other if Detect.STEAL in other else None
         if d:
             ret.steal_thresh = d.steal_thresh
+            ret.cmode = d.cmode
         d = self if Detect.RELAX in self else other if Detect.RELAX in other else None
         if d:
             ret.ur_thresh = d.ur_thresh
@@ -484,10 +486,13 @@ class StealDetect(Detect):
     steal_thresh: float
         If the average distance in pixels of two replays is smaller than
         this value, they are labeled cheated (stolen replays). Default 18.
+    cmode: :class:`~.CMode`
+        The algorithm, or combination thereof, used to compare replays.
     """
-    def __init__(self, steal_thresh=18):
+    def __init__(self, steal_thresh=18, cmode=FastCMode()):
         super().__init__(Detect.STEAL)
         self.steal_thresh = steal_thresh
+        self.cmode = cmode
 
 class RelaxDetect(Detect):
     """

--- a/circleguard/enums.py
+++ b/circleguard/enums.py
@@ -427,8 +427,13 @@ class SlowCMode(CMode):
     --------
     :class:`~.SlowCMode`, for a faster but less effective alternative.
     """
-    def __init__(self):
+    def __init__(self, search_step=16, step_limit=10):
+        # TODO this init is pretty bad, repeats ``SearchCMode`` 's init,
+        # but I'd like to be able to modify ``SearchCMode`` parameters directly
+        # through ``SlowCMode``.
         super().__init__(CMode.SLOW)
+        self.search_step = search_step
+        self.step_limit = step_limit
 
 
 class Detect():


### PR DESCRIPTION
* adds some semblance of the `CleanMode` structure the `cleaning-tests` branch had, but renamed to `CMode` (comparison mode), as I felt that was more descriptive.
* `SlowCMode` now tests both hill climbing and our standard comparison algorithm, returning the lower similarity of the two. Names and documentation have been updated to reflect this, I think
* should allow for users (read: circleguard) to transfer over to using hill climbing for searching easily, if they so choose