### PR TITLE
don't preprocess replay data if it's None

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* fix error when loading a replay that has replay info but is not downloadable
+
 # v3.2.1
 
 * correctly calculate ur for replays using mouse clicks (as opposed to keyboard clicks).

--- a/circleguard/loadable.py
+++ b/circleguard/loadable.py
@@ -511,6 +511,15 @@ class Replay(Loadable):
         self.replay_data = replay_data
         self.weight = weight
         self.loaded = True
+        # initialize in case ``replay_data`` is ``None``, still want
+        # the attributes
+        self.t = None
+        self.xy = None
+        self.k = None
+
+        # replay wasn't available, can't preprocess the data
+        if self.replay_data is None:
+            return
 
         block = list(zip(*[(e.time_since_previous_action, e.x, e.y, e.keys_pressed) for e in self.replay_data]))
 


### PR DESCRIPTION
When a replay exists but has no replay data, we would error. eg `r = ReplayMap(1911308, 7983776, Mod.HDDTHR)` has replay info available but is not downloadable. We attempted to do preprocessing on all replays.

should really have a test for this so it doesn't regress