### PR TITLE
add a few type hints

### DIFF
--- a/circleguard/circleguard.py
+++ b/circleguard/circleguard.py
@@ -5,7 +5,7 @@ import os
 from os.path import isfile, join
 import logging
 from tempfile import TemporaryDirectory
-from typing import Generator
+from typing import Iterable
 
 from circleguard.loader import Loader
 from circleguard.comparer import Comparer
@@ -65,7 +65,7 @@ class Circleguard:
 
 
     def run(self, loadables, detect, loadables2=None, max_angle=DEFAULT_ANGLE, min_distance=DEFAULT_DISTANCE)\
-        -> Generator[Result, None, None]:
+        -> Iterable[Result]:
         """
         Investigates loadables for cheats.
 
@@ -132,7 +132,7 @@ class Circleguard:
                     # disconnect from temporary library
                     library.close()
 
-    def steal_check(self, loadables, loadables2=None) -> Generator[StealResult, None, None]:
+    def steal_check(self, loadables, loadables2=None) -> Iterable[StealResult]:
         """
         Investigates loadables for replay stealing.
 
@@ -153,7 +153,7 @@ class Circleguard:
         """
         yield from self.run(loadables, Detect.STEAL, loadables2)
 
-    def relax_check(self, loadables) -> Generator[RelaxResult, None, None]:
+    def relax_check(self, loadables) -> Iterable[RelaxResult]:
         """
         Investigates loadables for relax.
 
@@ -171,7 +171,7 @@ class Circleguard:
         yield from self.run(loadables, Detect.RELAX)
 
     def correction_check(self, loadables, max_angle=DEFAULT_ANGLE, min_distance=DEFAULT_DISTANCE)\
-        -> Generator[CorrectionResult, None, None]:
+        -> Iterable[CorrectionResult]:
         """
         Investigates loadables for aim correction.
 

--- a/circleguard/circleguard.py
+++ b/circleguard/circleguard.py
@@ -5,6 +5,7 @@ import os
 from os.path import isfile, join
 import logging
 from tempfile import TemporaryDirectory
+from typing import Generator
 
 from circleguard.loader import Loader
 from circleguard.comparer import Comparer
@@ -13,6 +14,7 @@ from circleguard.cacher import Cacher
 from circleguard.exceptions import CircleguardException
 from circleguard.loadable import Check, ReplayMap, ReplayPath, Replay, Map
 from circleguard.enums import RatelimitWeight, Detect
+from circleguard.result import Result, StealResult, RelaxResult, CorrectionResult
 from slider import Beatmap, Library
 
 
@@ -62,7 +64,8 @@ class Circleguard:
             self.library = Library(slider_dir)
 
 
-    def run(self, loadables, detect, loadables2=None, max_angle=DEFAULT_ANGLE, min_distance=DEFAULT_DISTANCE):
+    def run(self, loadables, detect, loadables2=None, max_angle=DEFAULT_ANGLE, min_distance=DEFAULT_DISTANCE)\
+        -> Generator(Result, None, None):
         """
         Investigates loadables for cheats.
 
@@ -129,7 +132,7 @@ class Circleguard:
                     # disconnect from temporary library
                     library.close()
 
-    def steal_check(self, loadables, loadables2=None):
+    def steal_check(self, loadables, loadables2=None) -> Generator(StealResult, None, None):
         """
         Investigates loadables for replay stealing.
 
@@ -150,7 +153,7 @@ class Circleguard:
         """
         yield from self.run(loadables, Detect.STEAL, loadables2)
 
-    def relax_check(self, loadables):
+    def relax_check(self, loadables) -> Generator(RelaxResult, None, None):
         """
         Investigates loadables for relax.
 
@@ -167,7 +170,8 @@ class Circleguard:
         """
         yield from self.run(loadables, Detect.RELAX)
 
-    def correction_check(self, loadables, max_angle=DEFAULT_ANGLE, min_distance=DEFAULT_DISTANCE):
+    def correction_check(self, loadables, max_angle=DEFAULT_ANGLE, min_distance=DEFAULT_DISTANCE)\
+        -> Generator(CorrectionResult, None, None):
         """
         Investigates loadables for aim correction.
 

--- a/circleguard/circleguard.py
+++ b/circleguard/circleguard.py
@@ -65,7 +65,7 @@ class Circleguard:
 
 
     def run(self, loadables, detect, loadables2=None, max_angle=DEFAULT_ANGLE, min_distance=DEFAULT_DISTANCE)\
-        -> Generator(Result, None, None):
+        -> Generator[Result, None, None]:
         """
         Investigates loadables for cheats.
 
@@ -132,7 +132,7 @@ class Circleguard:
                     # disconnect from temporary library
                     library.close()
 
-    def steal_check(self, loadables, loadables2=None) -> Generator(StealResult, None, None):
+    def steal_check(self, loadables, loadables2=None) -> Generator[StealResult, None, None]:
         """
         Investigates loadables for replay stealing.
 
@@ -153,7 +153,7 @@ class Circleguard:
         """
         yield from self.run(loadables, Detect.STEAL, loadables2)
 
-    def relax_check(self, loadables) -> Generator(RelaxResult, None, None):
+    def relax_check(self, loadables) -> Generator[RelaxResult, None, None]:
         """
         Investigates loadables for relax.
 
@@ -171,7 +171,7 @@ class Circleguard:
         yield from self.run(loadables, Detect.RELAX)
 
     def correction_check(self, loadables, max_angle=DEFAULT_ANGLE, min_distance=DEFAULT_DISTANCE)\
-        -> Generator(CorrectionResult, None, None):
+        -> Generator[CorrectionResult, None, None]:
         """
         Investigates loadables for aim correction.
 

--- a/circleguard/result.py
+++ b/circleguard/result.py
@@ -118,6 +118,6 @@ class CorrectionResult(InvestigationResult):
         A list of suspicious hits in the replay.
     """
 
-    def __init__(self, replay, snaps):
+    def __init__(self, replay: Replay, snaps: list):
         super().__init__(replay, ResultType.CORRECTION)
         self.snaps = snaps


### PR DESCRIPTION
my linter (pylint) / IDE (vscode) don't seem to respect these type hints, so they're not useful unless someone is looking at the source, in which case we already document the return type. 

I'm curious if other editors treat type hints with more respect, though. Eg erroring when you do something contradictory to the type hint.