### PR TITLE
correct replay parsing logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* correctly order replay frames and remove invalid frames. This changes similarity values slightly
+
 # v4.0.2
 
 * loading replays from cache is now roughly twice as fast

--- a/circleguard/loadable.py
+++ b/circleguard/loadable.py
@@ -515,7 +515,8 @@ class Replay(Loadable):
         if replay_data[0].time_since_previous_action == 0:
             replay_data = replay_data[1:]
 
-        data = []
+        # t, x, y, k
+        data = [[], [], [], []]
         running_t = 0
         # negative frame times are valid when they're at the beginning of a
         # replay (they're frames from before the first hitobject at t=0).
@@ -535,10 +536,12 @@ class Replay(Loadable):
                 positive_seen = True
             running_t += e_t
 
-            d = (running_t, e.x, e.y, e.keys_pressed)
-            data.append(d)
+            data[0].append(running_t)
+            data[1].append(e.x)
+            data[2].append(e.y)
+            data[3].append(e.keys_pressed)
 
-        block = np.array(list(zip(*data)))
+        block = np.array(data)
 
         t = np.array(block[0], dtype=int)
         xy = np.array([block[1], block[2]], dtype=float).T

--- a/circleguard/loadable.py
+++ b/circleguard/loadable.py
@@ -544,10 +544,6 @@ class Replay(Loadable):
         xy = np.array([block[1], block[2]], dtype=float).T
         k = np.array(block[3], dtype=int)
 
-        for i in range(50):
-            print(t[i], xy[i])
-        print("=====================")
-
         t, t_sort = np.unique(t, return_index=True)
         xy = xy[t_sort]
         k = k[t_sort]

--- a/tests/test_investigations.py
+++ b/tests/test_investigations.py
@@ -22,7 +22,7 @@ class TestCorrection(CGTestCase):
         self.assertAlmostEqual(snaps[8].angle, 6.34890, delta=DELTA)
         self.assertAlmostEqual(snaps[8].distance, 27.59918, delta=DELTA)
         # end
-        self.assertEqual(snaps[14].time, 79052)
+        self.assertEqual(snaps[14].time, 79053)
         self.assertAlmostEqual(snaps[14].angle, 8.77141, delta=DELTA)
         self.assertAlmostEqual(snaps[14].distance, 8.21841, delta=DELTA)
 
@@ -50,7 +50,7 @@ class TestSteal(CGTestCase):
         earlier = r.earlier_replay
         later = r.later_replay
 
-        self.assertAlmostEqual(r.similarity, 2.19236, delta=DELTA, msg="Similarity is not correct")
+        self.assertAlmostEqual(r.similarity, 2.20915, delta=DELTA, msg="Similarity is not correct")
         self.assertEqual(r1.map_id, r2.map_id, "Replay map ids did not match")
         self.assertEqual(r1.map_id, 1988753, "Replay map id was not correct")
         self.assertEqual(earlier.mods, Mod.HD + Mod.HR, "Earlier replay mods was not correct")
@@ -71,7 +71,7 @@ class TestSteal(CGTestCase):
         earlier = r.earlier_replay
         later = r.later_replay
 
-        self.assertAlmostEqual(r.similarity, 23.03593, delta=DELTA, msg="Similarity is not correct")
+        self.assertAlmostEqual(r.similarity, 23.11035, delta=DELTA, msg="Similarity is not correct")
         self.assertEqual(r1.map_id, r2.map_id, "Replay map ids did not match")
         self.assertEqual(r1.map_id, 722238, "Replay map id was not correct")
         self.assertEqual(earlier.mods, Mod.HD + Mod.NC, "Earlier replay mods was not correct")
@@ -96,7 +96,7 @@ class TestSteal(CGTestCase):
             earlier = r.earlier_replay
             later = r.later_replay
 
-            self.assertAlmostEqual(r.similarity, 2.19236, delta=DELTA, msg=f"Similarity is not correct at num {num}")
+            self.assertAlmostEqual(r.similarity, 2.20915, delta=DELTA, msg=f"Similarity is not correct at num {num}")
             self.assertEqual(r1.map_id, r2.map_id, f"Replay map ids did not match at num {num}")
             self.assertEqual(r1.map_id, 1988753, f"r1 map id was not correct at num {num}")
             self.assertEqual(earlier.mods, Mod.HD + Mod.HR, f"Earlier replay mods was not correct at num {num}")


### PR DESCRIPTION
* remove invalid frame at the beginning of a replay (https://github.com/ppy/osu/blob/1587d4b26fbad691242544a62dbf017a78705ae3/osu.Game/Scoring/Legacy/LegacyScoreDecoder.cs#L242-L245)
* ignore frames with negative time values (after the first frames, which occur before the first map break)

Should be a slight speed decrease because we're iterating over `replay_data` twice, I can probably speed it up by writing the transpose (currently done by `block = np.array(list(zip(*data)))` into the loop so we're back to just one pass over `replay_data`.

This ignores negative time frames in the middle of replays entirely, which feels wrong, but is what lazer does (actually lazer also ignores negative time frames everywhere, including the beginning of replays). This should fix replay data getting out of order when we sort by cumulative time, because we respected negative frame replays and went backwards in time.

I've uploaded a replay that previously got out of order and is fixed with this pr.

[replay-osu_1534521_3078306009.osr.zip](https://github.com/circleguard/circlecore/files/4604346/replay-osu_1534521_3078306009.osr.zip)
