### PR TITLE
add default thresholds to Detect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 * correctly order replay frames and remove invalid frames. This changes similarity values slightly
+* add default cutoffs to `Detect` as `SIM_LIMIT` and `UR_LIMIT`. These are values we feel are enough to call a replay cheated. They are not used in our code but are provided as a convenience.
 
 # v4.0.2
 

--- a/circleguard/enums.py
+++ b/circleguard/enums.py
@@ -344,11 +344,25 @@ class RatelimitWeight(Enum):
 class Detect(IntFlag):
     """
     A cheat, or set of cheats, to investigate for.
+
+    Notes
+    -----
+    Also defines thresholds we feel are reasonable to determine a replay as
+    cheated. These should not be treated as certainty, as they definitely allow
+    false positives through. You should decide where you fall on the scale
+    of "few false positives, many false negatives" to "many false positives,
+    few false negatives" yourself. These values land somewhere in the middle,
+    but your use case could easily sway more in one direction or the other.
     """
     STEAL      = 1 << 0
     RELAX      = 1 << 1
     CORRECTION = 1 << 2
-    ALL = STEAL + RELAX + CORRECTION
+    ALL        = STEAL + RELAX + CORRECTION
+
+    THRESH_STEAL = 18
+    # unconverted ur threshold
+    THRESH_RELAX = 50
+    # no aim correction threshold - any snap is suspicious
 
 class ResultType(Enum):
     """

--- a/circleguard/enums.py
+++ b/circleguard/enums.py
@@ -348,20 +348,19 @@ class Detect(IntFlag):
     Notes
     -----
     Also defines thresholds we feel are reasonable to determine a replay as
-    cheated. These should not be treated as certainty, as they definitely allow
-    false positives through. You should decide where you fall on the scale
+    cheated. These values are more conservative - that is, we try to not give
+    false positives. You should decide where you fall on the scale
     of "few false positives, many false negatives" to "many false positives,
-    few false negatives" yourself. These values land somewhere in the middle,
-    but your use case could easily sway more in one direction or the other.
+    few false negatives" for yourself, if necessary.
     """
     STEAL      = 1 << 0
     RELAX      = 1 << 1
     CORRECTION = 1 << 2
     ALL        = STEAL + RELAX + CORRECTION
 
-    THRESH_STEAL = 18
+    SIM_LIMIT = 17
     # unconverted ur threshold
-    THRESH_RELAX = 50
+    UR_LIMIT = 50
     # no aim correction threshold - any snap is suspicious
 
 class ResultType(Enum):


### PR DESCRIPTION
this also makes the default cutoff for comparison 17 instead of 18, which is a change from previous. There have been a few legit replays at `17.9`, but very few in the lower decimals, or in `16.x`. Of course consumers are not obligated to use this threshold.