### PR TITLE
move removal of duplicate frame times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * split `StealResult` into `StealResultSim` and `StealResultCorr`
 * correctly order replay frames and remove invalid frames. This changes similarity values slightly
 * add default cutoffs to `Detect` as `SIM_LIMIT` and `UR_LIMIT`. These are values we feel are enough to call a replay cheated. They are not used in our code but are provided as a convenience.
+* don't remove frames with identical time values when processing replay data. This removal still occurrs, but only when the replays are investigated.
 
 # v4.0.2
 

--- a/circleguard/investigator.py
+++ b/circleguard/investigator.py
@@ -98,8 +98,12 @@ class Investigator:
         :meth:`~.aim_correction_sam` for an alternative, unused approach
         involving velocity and jerk.
         """
-        t = replay.t[1:-1]
-        xy = replay.xy
+        # when we leave mutliple frames with the same time values, they
+        # sometimes get detected (falesly) as aim correction.
+        # TODO Worth looking into a bit more to see if we can avoid it without
+        # removing the frames entirely.
+        t, xy = Investigator.remove_unique(replay.t, replay.xy)
+        t = t[1:-1]
 
         # labelling three consecutive points a, b and c
         ab = xy[1:-1] - xy[:-2]
@@ -219,6 +223,15 @@ class Investigator:
                 object_i += 1
 
         return array
+
+    # TODO (some) code duplication with this method and a similar one in
+    # ``Comparer``. Refactor Investigator and Comparer to inherit from a base
+    # class, or move this method to utils. Preferrably the former.
+    @staticmethod
+    def remove_unique(t, k):
+        t, t_sort = np.unique(t, return_index=True)
+        k = k[t_sort]
+        return (t, k)
 
 class Snap():
     """

--- a/circleguard/loadable.py
+++ b/circleguard/loadable.py
@@ -548,7 +548,9 @@ class Replay(Loadable):
         xy = np.array([block[1], block[2]], dtype=float).T
         k = np.array(block[3], dtype=int)
 
-        t, t_sort = np.unique(t, return_index=True)
+        # sort our data by t
+        t_sort = np.argsort(t)
+        t = t[t_sort]
         xy = xy[t_sort]
         k = k[t_sort]
 

--- a/tests/test_investigations.py
+++ b/tests/test_investigations.py
@@ -71,7 +71,7 @@ class TestSteal(CGTestCase):
     def test_cheated_time_shift(self):
         replays = [self.time_shifted1, self.time_shifted2]
         r = list(self.cg.steal_check(replays, method=Detect.STEAL_SIM))[0]
-        self.assertAlmostEqual(r.similarity, 17.30112, delta=DELTA, msg="Similarity is not correct")
+        self.assertAlmostEqual(r.similarity, 17.30119, delta=DELTA, msg="Similarity is not correct")
 
         # STEAL_SIM is currently *not* able to detect time shifts. If this
         # changes we want to know! :P


### PR DESCRIPTION
Don't remove frames with identical time values when processing replay data.

Our similarity algo and, to a lesser extent, our aim correction algo relies on there being unique times for each frame. Filtering now occurs in these algos instead of in replay processing.

This is useful to present users with the "raw" version of the replay, and not make decisions for them about what to keep.

I'll be honest, I don't know why the similarity for one of the comparisons changed, but it's so small I'm not going to worry about it. I probably should though, there's no reason we're doing anything different now, the location has just shifted.