### PR TITLE
fix negative frame times (again)

### DIFF
--- a/circleguard/loadable.py
+++ b/circleguard/loadable.py
@@ -639,48 +639,34 @@ class Replay(Loadable):
         # The following is guesswork, but seems to accurately describe replays.
         # This references the "first" frame assuming that we have already
         # removed the truly first zero time frame, if it is present. So
-        # technically the "first" frame below is the second frame.
-        # There are two possibilities for osrs:
+        # technically the "first" frame below may be the second frame.
+        # There are two possibilities for replays:
         # * for replays with a skip in the beginning, the first frame time is
         #   the skip duration. The next frame after that will have a negative
         #   time, to account for the replay data before the skip.
-        # * for replays without a skip in the beginning, the firstframe time is
+        # * for replays without a skip in the beginning, the first frame time is
         #   -1.
-        # Since in the first case the first frame time is positive, it would
-        # cause our loop below to ignore the negative time frame afterwards,
-        # throwing off the replay. To solve this we initiaize the running time
-        # to the first frame's time.
+        # Since in the first case the first frame time is a large positive,
+        # this would make ``highest_running_t`` large and cause all replay data
+        # before the skip to be ignored. To solve this, we initialize
+        # ``running_t`` to the first frame's time.
         running_t = next(replay_data).time_since_previous_action
-        # The following is more guesswork, but is again seemingly accurate.
-        # * We consider negative frames at the very beginning of a replay to be
-        #   valid (they're frames from before the start of the mp3 at t=0),
-        #   but only for the purposes of changing the running time - they are
-        #   not added to the final list of frames. We do this because lazer
-        #   does this. Lazer counts the time towards the running time, but skips
-        #   the frame otherwise. https://github.com/ppy/osu/blob/1587d4b26fbad691242544a62dbf017a78705ae3/osu.Game/Scoring/Legacy/LegacyScoreDecoder.cs#L247-L250.
-        #   There is typically (and potentially always) at most a single large
-        #   negative frame at the beginning of the replay, which occurs when the
-        #   replay has data before the break of a map.
-        # * We consider negative time frames in the middle of a replay to be
-        #   invalid. They are not counted towards the running time nor added
-        #   to the list of frames, but are entirely skipped. This is *not*
-        #   what lazer does (as far as I can tell), but if we respect negative
-        #   frames in the middle of a replay, they can cause frames which are
-        #   obviously next to each other when viewed in game to become entirely
-        #   out of order, as the negative frame puts us "backwards" in time.
-        #   Ignoring negative frames entirely after the beginning seems to
-        #   solve this issue. It may, however, not be the canonical solution.
-        positive_seen = False
-
+        # We consider negative time frames in the middle of replays to be valid,
+        # with a caveat. Their negative time is counted toward ``running_t``
+        # (that is, decreases ``running_t``), but any frames after it are
+        # ignored, until the total time passed of ignored frames is greater than
+        # or equal to the negative frame.
+        # I do not know why stable treats negative time frames in this way.
+        # It is not what lazer does, as far as I can tell. But it is the only
+        # reasonable explanation for stable behavior. This solution may not,
+        # however, be the canonical solution.
+        highest_running_t = np.NINF
         for e in replay_data:
             e_t = e.time_since_previous_action
-            if e_t < 0:
-                if not positive_seen:
-                    running_t += e_t
-                continue
-            else:
-                positive_seen = True
             running_t += e_t
+            highest_running_t = max(highest_running_t, running_t)
+            if running_t < highest_running_t:
+                continue
 
             data[0].append(running_t)
             data[1].append(e.x)

--- a/circleguard/loadable.py
+++ b/circleguard/loadable.py
@@ -636,10 +636,11 @@ class Replay(Loadable):
         # use an iter an an optimization so we don't recreate the list when
         # taking (and removing) the first element
         replay_data = iter(replay_data)
-        # The following is guesswork, but seems to accurately describe replays.
-        # This references the "first" frame assuming that we have already
-        # removed the truly first zero time frame, if it is present. So
-        # technically the "first" frame below may be the second frame.
+        # The following comments in this method are guesswork, but seems to
+        # accurately describe replays. This references the "first" frame
+        # assuming that we have already removed the truly first zero time frame,
+        # if it is present. So technically the "first" frame below may be the
+        # second frame.
         # There are two possibilities for replays:
         # * for replays with a skip in the beginning, the first frame time is
         #   the skip duration. The next frame after that will have a negative
@@ -656,22 +657,75 @@ class Replay(Loadable):
         # (that is, decreases ``running_t``), but any frames after it are
         # ignored, until the total time passed of ignored frames is greater than
         # or equal to the negative frame.
+        # There's one more catch - the frame that brings us *out* of this
+        # "negative time" section where we're ignoring frames will cause a
+        # special frame to be inserted, which has the same time as the frame
+        # that brought us *into* the negative time section, and specially
+        # calculated x and y positions. Details below.
         # I do not know why stable treats negative time frames in this way.
         # It is not what lazer does, as far as I can tell. But it is the only
         # reasonable explanation for stable behavior. This solution may not,
         # however, be the canonical solution.
         highest_running_t = np.NINF
+        # The last positive frame we encountered before entering a negative
+        # section.
+        last_positive_frame = None
+        # the running time when we encountered ``last_positive_fram``. We do not
+        # store this information in each individual frame.
+        last_positive_frame_cum_time = None
+        previous_frame = None
         for e in replay_data:
+            # check if we were in a negative section of the play at the previous
+            # frame (f0) before applying the current frame (f1), so we can
+            # apply special logic if f1 is the frame that gets us out of the
+            # negative section.
+            was_in_negative_section = running_t < highest_running_t
+
             e_t = e.time_since_previous_action
             running_t += e_t
             highest_running_t = max(highest_running_t, running_t)
             if running_t < highest_running_t:
+                # if we weren't in a negative section in f0, f1 is the first
+                # frame to bring us into one, so f0 is the last positive frame.
+                if not was_in_negative_section:
+                    last_positive_frame = previous_frame
+                    # we want to set it to the cumulative time before f1
+                    # was processed, so subtract out the current e_t
+                    last_positive_frame_cum_time = running_t - e_t
+                previous_frame = e
                 continue
+
+            # if we get here, f1 brought us out of the negative section. In this
+            # case, osu! actually inserts a new frame, with:
+            # * t = the cumulative time at the last positive frame (yes, this
+            #   means there are two frames at the same time in the replay
+            #   playback).
+            # * x, y = a weighted average between the positions of f0 and f1,
+            #   weighted by how close the last positive frame's time is to each
+            #   of the two frames' times.
+            # * k = the keypresses of the last positive frame.
+            if was_in_negative_section:
+                data[0].append(last_positive_frame_cum_time)
+
+                # this is [running_t at f0, running_t at f1], to interpolate
+                # the last positive frame's time between.
+                xp = [running_t - e_t, running_t]
+
+                fp = [previous_frame.x, e.x]
+                x = np.interp(last_positive_frame_cum_time, xp, fp)
+                data[1].append(x)
+
+                fp = [previous_frame.y, e.y]
+                y = np.interp(last_positive_frame_cum_time, xp, fp)
+                data[2].append(y)
+
+                data[3].append(last_positive_frame.keys_pressed)
 
             data[0].append(running_t)
             data[1].append(e.x)
             data[2].append(e.y)
             data[3].append(e.keys_pressed)
+            previous_frame = e
 
         block = np.array(data)
 

--- a/tests/test_investigations.py
+++ b/tests/test_investigations.py
@@ -23,7 +23,7 @@ class TestCorrection(CGTestCase):
         self.assertAlmostEqual(snaps[8].angle, 6.34890, delta=DELTA)
         self.assertAlmostEqual(snaps[8].distance, 27.59918, delta=DELTA)
         # end
-        self.assertEqual(snaps[14].time, 79053)
+        self.assertEqual(snaps[14].time, 79052)
         self.assertAlmostEqual(snaps[14].angle, 8.77141, delta=DELTA)
         self.assertAlmostEqual(snaps[14].distance, 8.21841, delta=DELTA)
 
@@ -37,8 +37,8 @@ class TestSteal(CGTestCase):
         cls.stolen2 = ReplayPath(RES / "stolen_replay2.osr")
         cls.legit1 = ReplayPath(RES / "legit_replay1.osr")
         cls.legit2 = ReplayPath(RES / "legit_replay2.osr")
-        cls.time_shifted1 = ReplayPath(RES / "stealing" / "stolen-time-shifted-1.osr")
-        cls.time_shifted2 = ReplayPath(RES / "stealing" / "stolen-time-shifted-2.osr")
+        cls.time_shifted1 = ReplayPath(RES / "stealing" / "stolen-time-shifted-1-1.osr")
+        cls.time_shifted2 = ReplayPath(RES / "stealing" / "stolen-time-shifted-1-2.osr")
 
     @staticmethod
     def add_noise_and_positional_translation_to_replay(replay, pixel_offset, std_deviation):
@@ -59,7 +59,7 @@ class TestSteal(CGTestCase):
         earlier = r.earlier_replay
         later = r.later_replay
 
-        self.assertAlmostEqual(r.similarity, 2.20915, delta=DELTA, msg="Similarity is not correct")
+        self.assertAlmostEqual(r.similarity, 2.20867, delta=DELTA, msg="Similarity is not correct")
         self.assertEqual(r1.map_id, r2.map_id, "Replay map ids did not match")
         self.assertEqual(r1.map_id, 1988753, "Replay map id was not correct")
         self.assertEqual(earlier.mods, Mod.HD + Mod.HR, "Earlier replay mods was not correct")
@@ -71,7 +71,7 @@ class TestSteal(CGTestCase):
     def test_cheated_time_shift(self):
         replays = [self.time_shifted1, self.time_shifted2]
         r = list(self.cg.steal_check(replays, method=Detect.STEAL_SIM))[0]
-        self.assertAlmostEqual(r.similarity, 17.30112, delta=DELTA, msg="Similarity is not correct")
+        self.assertAlmostEqual(r.similarity, 17.30254, delta=DELTA, msg="Similarity is not correct")
 
         # STEAL_SIM is currently *not* able to detect time shifts. If this
         # changes we want to know! :P
@@ -80,7 +80,7 @@ class TestSteal(CGTestCase):
         # STEAL_CORR should be able to, though.
         r = list(self.cg.steal_check(replays, method=Detect.STEAL_CORR))[0]
         self.assertGreater(r.correlation, Detect.CORR_LIMIT, "Cheated replays were not detected as cheated")
-        self.assertAlmostEqual(r.correlation, 0.99764, delta=DELTA, msg="Correlation is not correct")
+        self.assertAlmostEqual(r.correlation, 0.99734, delta=DELTA, msg="Correlation is not correct")
 
 
     def test_legitimate(self):
@@ -95,7 +95,7 @@ class TestSteal(CGTestCase):
         earlier = r.earlier_replay
         later = r.later_replay
 
-        self.assertAlmostEqual(r.similarity, 23.11035, delta=DELTA, msg="Similarity is not correct")
+        self.assertAlmostEqual(r.similarity, 23.13951, delta=DELTA, msg="Similarity is not correct")
         self.assertEqual(r1.map_id, r2.map_id, "Replay map ids did not match")
         self.assertEqual(r1.map_id, 722238, "Replay map id was not correct")
         self.assertEqual(earlier.mods, Mod.HD + Mod.NC, "Earlier replay mods was not correct")
@@ -120,7 +120,7 @@ class TestSteal(CGTestCase):
             earlier = r.earlier_replay
             later = r.later_replay
 
-            self.assertAlmostEqual(r.similarity, 2.20915, delta=DELTA, msg=f"Similarity is not correct at num {num}")
+            self.assertAlmostEqual(r.similarity, 2.20867, delta=DELTA, msg=f"Similarity is not correct at num {num}")
             self.assertEqual(r1.map_id, r2.map_id, f"Replay map ids did not match at num {num}")
             self.assertEqual(r1.map_id, 1988753, f"r1 map id was not correct at num {num}")
             self.assertEqual(earlier.mods, Mod.HD + Mod.HR, f"Earlier replay mods was not correct at num {num}")


### PR DESCRIPTION
This is sort of an update to #144.

Oh man, negative frame times, what a mess. @sometimeszzzzzzz did some investigative work and found that when osu! encounters a negative frame (hereby frame 1), it actually *ignores* any future frames, until enough time (greater than or equal to the negative frame time) has passed. The frame that puts the time over this threshold (frame 2) is counted.

But that would be too simple! osu! also inserts an additional frame (frame 3) when it encounters frame 2, with the same cumulative time as frame 1. Not only that, but the position of frame 3 is actually a linear interpolation between the coordinates of frame 2 and the frame before frame 2. I don't know how frame 3's keypresses are determined and I'm not sure I really care at this point (though if someone finds out feel free to tell me), so I assumed it copies frame 1's keypresses.

Let's take a concrete example. I'll be referring to frames by their cumulative time - this can get confusing, as frames with lower cumulative time are not always earlier, thanks to negative frames.

![image](https://user-images.githubusercontent.com/31628143/88131593-57bbe800-cbab-11ea-92b8-208270cae392.png)

Here, the first frame 15 is the negative frame - ie, frame 1 above. The second frame 15 and frames 27 and 51 are skipped, as their times are not enough to overcome `-48`. Frame 74, however, does put the total time after encountering frame 1 to above `-48`, and is thus counted (this is frame 2 above). 

Now we must calculate the additional frame to insert. We give it frame 1's cumulative time, `63`, and a position which is linearly interpolated between the points `(206, 310.8)` (from the frame before frame 2) and `(220, 322)` (from frame 2). This results in a position of `(213.3, 316.6)`, and is inserted into the replay data as a normal frame.

The example above was taken from the replay linked on #144; https://github.com/circleguard/circlecore/files/4604346/replay-osu_1534521_3078306009.osr.zip.