### PR TITLE
move from circleparse to osrparse

### DIFF
--- a/circleguard/loadables.py
+++ b/circleguard/loadables.py
@@ -5,7 +5,7 @@ import os
 import sqlite3
 import random
 
-import circleparse
+import osrparse
 import numpy as np
 import wtc
 
@@ -660,8 +660,8 @@ class Replay(Loadable):
 
         Paramters
         ---------
-        replay_data: list[:class:`~circleparse.Replay.ReplayEvent`]
-            A list of :class:`~circleparse.Replay.ReplayEvent` objects,
+        replay_data: list[:class:`~osrparse.Replay.ReplayEvent`]
+            A list of :class:`~osrparse.Replay.ReplayEvent` objects,
             representing the actual data of the replay. If the replay could not
             be loaded, this should be ``None``.
 
@@ -1024,7 +1024,7 @@ class ReplayPath(Replay):
             self.log.debug("%s already loaded, not loading", self)
             return
 
-        loaded = circleparse.parse_replay_file(self.path)
+        loaded = osrparse.parse_replay_file(self.path)
         self.game_version = GameVersion(loaded.game_version, concrete=True)
         self.timestamp = loaded.timestamp
         self.map_id = loader.map_id(loaded.beatmap_hash)
@@ -1033,7 +1033,7 @@ class ReplayPath(Replay):
         # `Loader#user_id` function to use later to load it.
         self._user_id_func = loader.user_id
         self._user_id = None
-        self.mods = Mod(loaded.mod_combination)
+        self.mods = Mod(int(loaded.mod_combination))
         self.replay_id = loaded.replay_id
         self.beatmap_hash = loaded.beatmap_hash
 
@@ -1170,7 +1170,7 @@ class ReplayString(Replay):
             self.log.debug("%s already loaded, not loading", self)
             return
 
-        loaded = circleparse.parse_replay(self.replay_data_str, pure_lzma=False)
+        loaded = osrparse.parse_replay(self.replay_data_str, pure_lzma=False)
         self.game_version = GameVersion(loaded.game_version, concrete=True)
         self.timestamp = loaded.timestamp
         self.map_id = loader.map_id(loaded.beatmap_hash)
@@ -1285,7 +1285,7 @@ class CachedReplay(Replay):
         if self.loaded:
             return
         decompressed = wtc.decompress(self.replay_data)
-        parsed = circleparse.parse_replay(decompressed, pure_lzma=True)
+        parsed = osrparse.parse_replay(decompressed, pure_lzma=True)
         self._process_replay_data(parsed.play_data)
         self.loaded = True
 

--- a/circleguard/loader.py
+++ b/circleguard/loader.py
@@ -7,7 +7,7 @@ from functools import lru_cache
 from enum import Enum
 
 from requests import RequestException
-import circleparse
+import osrparse
 import ossapi
 
 from circleguard.mod import Mod
@@ -177,7 +177,7 @@ def check_cache(function):
 
         decompressed_lzma = self.cacher.check_cache(replay_info)
         if decompressed_lzma:
-            parsed = circleparse.parse_replay(decompressed_lzma, \
+            parsed = osrparse.parse_replay(decompressed_lzma, \
                 pure_lzma=True, decompressed_lzma=True)
             return parsed.play_data
         else:
@@ -418,7 +418,7 @@ class Loader():
 
         Returns
         -------
-        list[:class:`circleparse.replay.ReplayEvent`]
+        list[:class:`osrparse.replay.ReplayEvent`]
             The replay events with attributes ``x``, ``y``,
             ``time_since_previous_action``, and ``keys_pressed``.
         None
@@ -444,7 +444,7 @@ class Loader():
             raise UnknownAPIException("The api guaranteed there would be a "
                 "replay available, but we did not receive any data.")
         try:
-            parsed_replay = circleparse.parse_replay(lzma_bytes, pure_lzma=True)
+            parsed_replay = osrparse.parse_replay(lzma_bytes, pure_lzma=True)
         # see https://github.com/circleguard/circlecore/issues/61
         # api sometimes returns corrupt replays
         except LZMAError:
@@ -470,7 +470,7 @@ class Loader():
         response = self.api.get_replay({"s": replay_id})
         Loader.check_response(response)
         lzma = base64.b64decode(response["content"])
-        replay_data = circleparse.parse_replay(lzma, pure_lzma=True).play_data
+        replay_data = osrparse.parse_replay(lzma, pure_lzma=True).play_data
         # TODO cache the replay here, might require some restructring/double
         # checking everything will work because we only have its id, not map
         # or user id. In fact I think our db asserts map and user id are nonull

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     license = "MIT",
     packages=find_packages(),
     install_requires=[
-        "circleparse~=6.4.0",
+        "osrparse~=4.0.0",
         "ossapi==1.3.0",
         "wtc==1.2.1",
         "numpy",


### PR DESCRIPTION
All the changes we were relying on in circleparse have been merged upstream (see https://github.com/kszlim/osu-replay-parser/pull/25), so we can move to osrparse instead now.