### PR TITLE
update for osrparse 6.0.0

### DIFF
--- a/circleguard/loader.py
+++ b/circleguard/loader.py
@@ -50,9 +50,7 @@ def check_cache(function):
         if not decompressed_lzma:
             return function(*args, **kwargs)
 
-        parsed = osrparse.parse_replay(decompressed_lzma, pure_lzma=True,
-            decompressed_lzma=True)
-        return parsed.play_data
+        return osrparse.parse_replay_data(decompressed_lzma, decompressed=True)
     return wrapper
 
 
@@ -310,18 +308,20 @@ class Loader:
             return None
 
         lzma_bytes = self.load_replay_data(beatmap_id, user_id, mods)
+        # TODO can this ever be `None`? shouldn't the `base64.b64decode` call in
+        # `self.load_replay_data` error on a `None` value? in other words, I
+        # don't see how the decode function could ever return `None`.
         if lzma_bytes is None:
             raise ReplayUnavailableException("The api guaranteed there "
                 "would be a replay available, but we did not receive any data.")
         try:
-            parsed_replay = osrparse.parse_replay(lzma_bytes, pure_lzma=True)
+            replay_data = osrparse.parse_replay_data(lzma_bytes, decoded=True)
         # see https://github.com/circleguard/circlecore/issues/61
         # api sometimes returns corrupt replays
         except LZMAError:
             self.log.warning("lzma from %r could not be decompressed, api "
                 "returned corrupt replay", replay_info)
             return None
-        replay_data = parsed_replay.play_data
         if cache:
             self._cache(lzma_bytes, replay_info)
         return replay_data
@@ -337,8 +337,7 @@ class Loader:
             The id of the replay to retrieve data for.
         """
         content = self.api.get_replay(score_id=replay_id)
-        lzma = base64.b64decode(content)
-        replay_data = osrparse.parse_replay(lzma, pure_lzma=True).play_data
+        replay_data = osrparse.parse_replay_data(content)
         # TODO cache the replay here, might require some restructuring/double
         # checking everything will work because we only have its id, not map
         # or user id. In fact I think our db asserts map and user id are nonull

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     download_url = "https://github.com/circleguard/circlecore/tarball/v" + VERSION,
     packages=find_packages(),
     install_requires=[
-        "osrparse~=5.0",
+        "osrparse~=6.0",
         "ossapi~=2.1",
         "wtc==1.2.1",
         "numpy",

--- a/tests/test_loadables.py
+++ b/tests/test_loadables.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 
 from circleguard import (ReplayMap, ReplayPath, RatelimitWeight, Map, User,
     MapUser, Mod, NoInfoAvailableException, ReplayString)
@@ -30,7 +30,8 @@ class TestReplays(CGTestCase):
         self.assertEqual(r.max_combo, 186)
         self.assertTrue(r.is_perfect_combo)
         self.assertEqual(r.life_bar_graph, "")
-        self.assertEqual(r.timestamp, datetime(2015, 12, 16, 19, 40, 39))
+        self.assertEqual(r.timestamp, datetime(2015, 12, 16, 19, 40, 39,
+            tzinfo=timezone.utc))
 
     def test_loading_replaymap(self):
         # Toy HDHR score on Pretender
@@ -133,12 +134,12 @@ class TestUser(CGTestCase):
     def test_user_slice(self):
         # sanity check (user id better be what we put in)
         self.assertEqual(self.user[0].user_id, 124493)
-        # 2nd (Everything will Freeze)
-        self.assertEqual(self.user[1].map_id, 555797)
-        # 1st, 2nd, and 3rd (FDFD, Everything will Freeze, and Remote Control)
-        self.assertListEqual([r.map_id for r in self.user[0:3]], [129891, 555797, 774965])
-        # 1st and 3rd (FDFD and Remote Control)
-        self.assertListEqual([r.map_id for r in self.user[0:3:2]], [129891, 774965])
+        # 2nd (Remote Control)
+        self.assertEqual(self.user[1].map_id, 774965)
+        # 1st, 2nd, and 3rd (FDFD, Remote Control, and Glorious Crown)
+        self.assertListEqual([r.map_id for r in self.user[0:3]], [129891, 774965, 1181761])
+        # 1st and 3rd (FDFD and Glorious Crown)
+        self.assertListEqual([r.map_id for r in self.user[0:3:2]], [129891, 1181761])
 
     def test_no_replays_does_not_raise(self):
         u = User(12092800, "1-2", Mod.FL + Mod.EZ)

--- a/tests/test_loadables.py
+++ b/tests/test_loadables.py
@@ -29,7 +29,7 @@ class TestReplays(CGTestCase):
         self.assertEqual(r.score, 1083482)
         self.assertEqual(r.max_combo, 186)
         self.assertTrue(r.is_perfect_combo)
-        self.assertEqual(r.life_bar_graph, "")
+        self.assertEqual(r.life_bar_graph, None)
         self.assertEqual(r.timestamp, datetime(2015, 12, 16, 19, 40, 39,
             tzinfo=timezone.utc))
 


### PR DESCRIPTION
depends on https://github.com/kszlim/osu-replay-parser/pull/30

also fixes a test for cookiezi's new top plays