### PR TITLE
fix: return entire array if no outliers are found

### DIFF
--- a/circleguard/utils.py
+++ b/circleguard/utils.py
@@ -235,8 +235,8 @@ def filter_outliers(arr, bias=1.5):
     iqr = q3 - q1
     lower_limit = q1 - (bias * iqr)
     upper_limit = q3 + (bias * iqr)
-    outliers = [x for x in arr if lower_limit < x < upper_limit]
-    return arr if not outliers else outliers
+    arr_without_outliers = [x for x in arr if lower_limit < x < upper_limit]
+    return arr if not arr_without_outliers else arr_without_outliers
 
 
 TRACE = 5


### PR DESCRIPTION
fix in the `filter_outliers` method, with previous behavior if no outliers were found, an empty array would have been returned. this results in adjusted ur calculation being `None` in some replays (while normal ur calculation would be fine)

this conflicts with the usage and documentation of the method, which states that it'd return the array *with* the outliers removed.

to fix this, we simply return the original array if no outliers were found.