### PR TITLE
NumPy v2 prep: Use `-np.inf` instead of `np.NINF`

### DIFF
--- a/circleguard/loadables.py
+++ b/circleguard/loadables.py
@@ -794,7 +794,7 @@ class Replay(Loadable):
         # It is not what lazer does, as far as I can tell. But it is the only
         # reasonable explanation for stable behavior. This solution may not,
         # however, be the canonical solution.
-        highest_running_t = np.NINF
+        highest_running_t = -np.inf
         # The last positive frame we encountered before entering a negative
         # section.
         last_positive_frame = None


### PR DESCRIPTION
Noticed when setting up a new venv (it installs NumPy `v2.0RC` by default).

Should be compatible with v1 builds also.

```py
File "/run/media/stedos/NVMe/Development/Personal/Circleguard/circlecore/env-linux/lib/python3.11/site-packages/numpy-2.0.0rc2-py3.11-linux-x86_64.egg/numpy/__init__.py", line 397, in __getattr__
    raise AttributeError(
AttributeError: `np.NINF` was removed in the NumPy 2.0 release. Use `-np.inf` instead.
```